### PR TITLE
Align delivery status wording with design issue 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ import os
 from mesht_device import MeshtDevice
 from mesht_db import MeshtDb
 from packet_parsing import parse_text_packet, parse_delivery_packet, is_dm_for
+from delivery_status import delivery_status_text
 from transport_serial import SerialTransport
 
 
@@ -218,7 +219,13 @@ async def run():
                 request_id = delivery.request_id
                 if request_id in pending:
                     peer_hex = pending.pop(request_id)
-                    status = (delivery.status or "").upper()
+                    ack_nodes = {delivery.reporter_hex} if delivery.reporter_hex else set()
+                    status = delivery_status_text(
+                        delivery.status,
+                        ack_nodes=ack_nodes,
+                        direct_peer_hex=peer_hex,
+                        error_reason=delivery.error_reason,
+                    )
                     print(f"Delivery for {request_id} to {peer_hex}: {status}")
 
             # Handle incoming direct text packets.

--- a/chat.py
+++ b/chat.py
@@ -702,20 +702,8 @@ async def main_async(args):
             status_suffix = ""
             if msg.get("type") == "ToRadio":
                 name = msg.get("sender_long_name") or msg.get("sender_short_name") or my_display_name()
-                status = (msg.get("delivery_status") or "waiting").lower()
-                if status == "ack":
-                    if is_direct:
-                        status_suffix = "  [ACK]"
-                    else:
-                        ack_count = int(msg.get("delivery_ack_count") or 0)
-                        if ack_count > 0:
-                            status_suffix = f"  [{ack_count} ACK]"
-                        else:
-                            status_suffix = "  [ACK]"
-                elif status == "failed":
-                    status_suffix = "  [FAILED]"
-                else:
-                    status_suffix = "  [WAITING]"
+                status_text = msg.get("delivery_status_text") or "Sending..."
+                status_suffix = f"  {status_text}"
             else:
                 sender = msg.get("from")
                 name = resolve_sender_name(sender, msg)
@@ -791,7 +779,7 @@ async def main_async(args):
                                         ui.add_message(f"{name}: {text}", ts_epoch=ts if ts else None)
                                         needs_redraw.set()
                         elif parse_delivery_packet(pkt) is not None:
-                            # Routing updates can change [WAITING]/[ACK]/[FAILED] on sent messages.
+                            # Routing updates can change the status text on sent messages.
                             reload_chat_messages()
                             needs_redraw.set()
                         # While viewing nodes, reflect last-heard changes promptly

--- a/delivery_status.py
+++ b/delivery_status.py
@@ -1,0 +1,43 @@
+ROUTING_ERROR_TEXT = {
+    1: "Failed to deliver to mesh",
+    2: "Failed to deliver to mesh",
+    3: "Failed to deliver to mesh",
+    4: "No radio interface",
+    5: "Failed to deliver to mesh",
+    6: "Channel/key mismatch",
+    7: "Message is too large to send",
+    8: "No app response",
+    9: "Duty cycle limit",
+    32: "Invalid request",
+    33: "Not authorized",
+    34: "Could not send encrypted message",
+    35: "Recipient needs your key",
+    36: "Admin session expired",
+    37: "Admin key not authorized",
+    38: "Rate limited",
+    39: "Recipient key unavailable",
+}
+
+
+def routing_error_text(error_reason):
+    try:
+        return ROUTING_ERROR_TEXT.get(int(error_reason), "Failed to deliver to mesh")
+    except Exception:
+        return "Failed to deliver to mesh"
+
+
+def delivery_status_text(status, ack_nodes=None, direct_peer_hex=None, error_reason=None):
+    normalized = (status or "waiting").lower()
+    if normalized == "waiting":
+        return "Sending..."
+    if normalized == "failed":
+        return routing_error_text(error_reason)
+    if normalized == "ack":
+        if direct_peer_hex:
+            peer = direct_peer_hex.lower()
+            nodes = {(node or "").lower() for node in (ack_nodes or set())}
+            if peer in nodes:
+                return "Delivered to recipient"
+            return "Relayed, not confirmed by recipient"
+        return "Delivered to mesh"
+    return "Sending..."

--- a/mesht_db.py
+++ b/mesht_db.py
@@ -8,6 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import pb
+from delivery_status import delivery_status_text
 from mesht_device import TORADIO_SCHEMA, FROMRADIO_SCHEMA, PORTNUMS, Channel, USER_SCHEMA
 from packet_parsing import parse_text_packet, parse_delivery_packet, direct_peer_hex
 
@@ -329,7 +330,7 @@ class MeshtDb:
         node_hex = (node_id or "").lower()
         path = self._direct_messages_path(node_hex)
         lines = _load_jsonl(path)
-        messages = self._filter_text_entries(lines)
+        messages = self._filter_text_entries(lines, direct_peer_hex=node_hex)
         key_events = self._build_key_events(node_hex)
         combined = []
         order = 0
@@ -458,7 +459,7 @@ class MeshtDb:
         node_hex = (node_hex or "").lower()
         return os.path.join(self.data_dir, f"messages.dm.{node_hex}.jsonl")
 
-    def _filter_text_entries(self, lines):
+    def _filter_text_entries(self, lines, direct_peer_hex=None):
         out = []
         status_state_by_message_id = {}
 
@@ -477,11 +478,13 @@ class MeshtDb:
             if st is None:
                 st = {
                     "saw_failed": False,
+                    "failed_error_reason": None,
                     "ack_nodes": set(),
                 }
                 status_state_by_message_id[mid] = st
             if status == "failed":
                 st["saw_failed"] = True
+                st["failed_error_reason"] = entry.get("error_reason")
             elif status == "ack":
                 sender_hex = (entry.get("from") or "").lower()
                 if sender_hex:
@@ -507,17 +510,27 @@ class MeshtDb:
                 message_id = entry.get("message_id")
                 resolved = "waiting"
                 ack_count = 0
+                ack_nodes = set()
+                error_reason = None
                 if message_id is not None:
                     st = status_state_by_message_id.get(int(message_id))
                     if st is not None:
-                        ack_count = len(st.get("ack_nodes") or set())
+                        ack_nodes = st.get("ack_nodes") or set()
+                        ack_count = len(ack_nodes)
                         if ack_count > 0:
                             resolved = "ack"
                         elif st.get("saw_failed"):
                             resolved = "failed"
+                            error_reason = st.get("failed_error_reason")
                 text_entry = dict(entry)
                 text_entry["delivery_status"] = resolved
                 text_entry["delivery_ack_count"] = ack_count
+                text_entry["delivery_status_text"] = delivery_status_text(
+                    resolved,
+                    ack_nodes=ack_nodes,
+                    direct_peer_hex=direct_peer_hex,
+                    error_reason=error_reason,
+                )
                 out.append(text_entry)
                 continue
 

--- a/tests/test_delivery_status.py
+++ b/tests/test_delivery_status.py
@@ -1,0 +1,23 @@
+from delivery_status import delivery_status_text, routing_error_text
+
+
+def test_delivery_status_text_for_channel_ack():
+    assert delivery_status_text("ack", ack_nodes={"00000002"}) == "Delivered to mesh"
+
+
+def test_delivery_status_text_for_direct_ack_from_recipient():
+    assert (
+        delivery_status_text("ack", ack_nodes={"00000002"}, direct_peer_hex="00000002")
+        == "Delivered to recipient"
+    )
+
+
+def test_delivery_status_text_for_direct_ack_from_relay():
+    assert (
+        delivery_status_text("ack", ack_nodes={"00000003"}, direct_peer_hex="00000002")
+        == "Relayed, not confirmed by recipient"
+    )
+
+
+def test_routing_error_text_uses_canonical_channel_key_mismatch():
+    assert routing_error_text(6) == "Channel/key mismatch"

--- a/tests/test_radio_db.py
+++ b/tests/test_radio_db.py
@@ -644,6 +644,7 @@ def test_meshtdb_updates_sent_message_status_to_ack(tmp_path):
         assert resolved
         assert resolved[-1].get("delivery_status") == "ack"
         assert resolved[-1].get("delivery_ack_count") == 1
+        assert resolved[-1].get("delivery_status_text") == "Delivered to mesh"
 
         await db.close()
 
@@ -707,6 +708,7 @@ def test_meshtdb_updates_sent_message_status_to_failed(tmp_path):
         assert resolved
         assert resolved[-1].get("delivery_status") == "failed"
         assert resolved[-1].get("delivery_ack_count") == 0
+        assert resolved[-1].get("delivery_status_text") == "Channel/key mismatch"
 
         await db.close()
 
@@ -790,6 +792,7 @@ def test_meshtdb_channel_ack_count_dedupes_nodes(tmp_path):
         assert resolved
         assert resolved[-1].get("delivery_status") == "ack"
         assert resolved[-1].get("delivery_ack_count") == 2
+        assert resolved[-1].get("delivery_status_text") == "Delivered to mesh"
 
         await db.close()
 


### PR DESCRIPTION
## Tracking

- Design source of truth: https://github.com/meshtastic/design/issues/43
- Repo-specific issue: none opened; this draft PR is the tracking item for this community client.

## Summary

Align MiniMeshT's sender-facing message delivery status text with the current shared wording being standardized in meshtastic/design#43.

This is a wording/status-presentation change only. It does not change radio retry behavior, ACK/NAK behavior, or routing semantics.

## Wording covered

- `Sending...`
- `Delivered to mesh`
- `Delivered to recipient`
- `Relayed, not confirmed by recipient`
- `Failed to deliver to mesh`
- `Channel/key mismatch`
- `No radio interface`
- `Duty cycle limit`
- `Rate limited`
- `Message is too large to send`
- `No app response`
- `Invalid request`
- `Not authorized`
- `Could not send encrypted message`
- `Recipient needs your key`
- `Recipient key unavailable`
- `Admin session expired`
- `Admin key not authorized`

## Implementation notes

- Adds a shared mapper for MiniMeshT delivery status display text.
- Uses routing error reason codes to show the source-backed wording from the design issue where MiniMeshT has that data.
- Preserves the distinction between a direct recipient ACK and a relay/implicit ACK.
- Updates the README delivery-receipt example to use the same wording mapper.
- Keeps the terminal UI plain and native; no chips, badges, extra iconography, screenshots, logs, or validation artifacts are committed.

## Validation

- `/tmp/minimesht-wording-venv/bin/python -m pytest` -> 33 passed
- `python3.11 -m compileall chat.py mesht_db.py delivery_status.py`
- Searched changed source/docs for stale visible delivery-status wording.

## Draft / evidence status

This PR remains draft because I have not verified the updated wording against real Meshtastic hardware or captured reviewed terminal UI evidence for the relevant states. The changed mapping and message-history display behavior are covered by tests.
